### PR TITLE
Desktop icon + more understandable port names

### DIFF
--- a/qmodbus.desktop
+++ b/qmodbus.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=QModBus
+Comment=ModBus master emulator with GUI
+Exec=/usr/share/qmodbus/build/qmodbus
+Icon=/usr/share/qmodbus/data/logo.png
+Terminal=false
+Categories=Development;Electronics;
+Keywords=embedded electronics;electronics;microcontroller;
+X-Desktop-File-Install-Version=0.01

--- a/src/serialsettingswidget.cpp
+++ b/src/serialsettingswidget.cpp
@@ -26,7 +26,7 @@ int SerialSettingsWidget::setupModbusPort()
 	int i = 0;
 	foreach( QextPortInfo port, QextSerialEnumerator::getPorts() )
 	{
-		ui->serialPort->addItem( port.friendName );
+		ui->serialPort->addItem( port.physName );
 		if( port.friendName == s.value( "serialinterface" ) )
 		{
 			portIndex = i;


### PR DESCRIPTION
Hi!
Thank you for this excellent program! Been using it for a while, it's almost flawless
I've added a .desktop entry for qmodbus so that it can be installed if desired.
Also, I've changed how serial ports are represented on Linux, due to many possible ports and necessity to differentiate between them using not a number, which seems to be almost voluntarily assignable and incomprehensible in cases when there are different serial device prefixes in /dev (such as /dev/ttyUSB and /dev/ttyACM), but a device file path, which leaves no possibility to select a wrong port.
Yours sincerely,
Arsenijs.