### PR TITLE
Display errors in status-area, not dialogs

### DIFF
--- a/src/asciisettingswidget.cpp
+++ b/src/asciisettingswidget.cpp
@@ -3,8 +3,6 @@
 #include "ui_serialsettingswidget.h"
 #include "modbus.h"
 
-#include <QMessageBox>
-
 AsciiSettingsWidget::AsciiSettingsWidget(QWidget *parent) :
     SerialSettingsWidget(parent)
 {

--- a/src/asciisettingswidget.cpp
+++ b/src/asciisettingswidget.cpp
@@ -30,8 +30,8 @@ void AsciiSettingsWidget::changeModbusInterface(const QString& port, char parity
 
 	if( modbus_connect( m_serialModbus ) == -1 )
 	{
-		QMessageBox::critical( this, tr( "Connection failed" ),
-			tr( "Could not connect serial port!" ) );
+		emit connectionError( tr( "Could not connect serial port!" ) );
+
 		releaseSerialModbus();
 	}
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -559,5 +559,7 @@ void MainWindow::onTcpPortActive(bool active)
 
 void MainWindow::onConnectionError(const QString &msg)
 {
-    QMessageBox::critical( this, tr( "Connection failed" ), msg );
+    m_statusText->setText( msg );
+
+    m_statusInd->setStyleSheet( "background: red;" );
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -52,9 +52,14 @@ MainWindow::MainWindow( QWidget * _parent ) :
 {
 	ui->setupUi(this);
 
-	connect( ui->rtuSettingsWidget, SIGNAL(serialPortActive(bool)), this , SLOT(onRtuPortActive(bool)));
-    connect( ui->asciiSettingsWidget, SIGNAL(serialPortActive(bool)), this , SLOT(onAsciiPortActive(bool)));
-	connect( ui->tcpSettingsWidget,   SIGNAL(tcpPortActive(bool)), this, SLOT(onTcpPortActive(bool)));
+	connect( ui->rtuSettingsWidget,   SIGNAL(serialPortActive(bool)), this, SLOT(onRtuPortActive(bool)));
+	connect( ui->asciiSettingsWidget, SIGNAL(serialPortActive(bool)), this, SLOT(onAsciiPortActive(bool)));
+	connect( ui->tcpSettingsWidget,   SIGNAL(tcpPortActive(bool)),    this, SLOT(onTcpPortActive(bool)));
+
+	connect( ui->rtuSettingsWidget,   SIGNAL(connectionError(const QString&)), this, SLOT(onConnectionError(const QString&)));
+	connect( ui->asciiSettingsWidget, SIGNAL(connectionError(const QString&)), this, SLOT(onConnectionError(const QString&)));
+	connect( ui->tcpSettingsWidget,   SIGNAL(connectionError(const QString&)), this, SLOT(onConnectionError(const QString&)));
+
 	connect( ui->slaveID, SIGNAL( valueChanged( int ) ),
 			this, SLOT( updateRequestPreview() ) );
 	connect( ui->functionCode, SIGNAL( currentIndexChanged( int ) ),
@@ -552,4 +557,7 @@ void MainWindow::onTcpPortActive(bool active)
 	}
 }
 
-
+void MainWindow::onConnectionError(const QString &msg)
+{
+    QMessageBox::critical( this, tr( "Connection failed" ), msg );
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -569,4 +569,6 @@ void MainWindow::setStatusError(const QString &msg)
     m_statusText->setText( msg );
 
     m_statusInd->setStyleSheet( "background: red;" );
+
+    QTimer::singleShot( 2000, this, SLOT( resetStatus() ) );
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -55,9 +55,9 @@ MainWindow::MainWindow( QWidget * _parent ) :
 	connect( ui->asciiSettingsWidget, SIGNAL(serialPortActive(bool)), this, SLOT(onAsciiPortActive(bool)));
 	connect( ui->tcpSettingsWidget,   SIGNAL(tcpPortActive(bool)),    this, SLOT(onTcpPortActive(bool)));
 
-	connect( ui->rtuSettingsWidget,   SIGNAL(connectionError(const QString&)), this, SLOT(onConnectionError(const QString&)));
-	connect( ui->asciiSettingsWidget, SIGNAL(connectionError(const QString&)), this, SLOT(onConnectionError(const QString&)));
-	connect( ui->tcpSettingsWidget,   SIGNAL(connectionError(const QString&)), this, SLOT(onConnectionError(const QString&)));
+	connect( ui->rtuSettingsWidget,   SIGNAL(connectionError(const QString&)), this, SLOT(setStatusError(const QString&)));
+	connect( ui->asciiSettingsWidget, SIGNAL(connectionError(const QString&)), this, SLOT(setStatusError(const QString&)));
+	connect( ui->tcpSettingsWidget,   SIGNAL(connectionError(const QString&)), this, SLOT(setStatusError(const QString&)));
 
 	connect( ui->slaveID, SIGNAL( valueChanged( int ) ),
 			this, SLOT( updateRequestPreview() ) );
@@ -492,7 +492,7 @@ void MainWindow::sendModbusRequest( void )
 		}
 
 		if( err.size() > 0 )
-			onConnectionError( err );
+			setStatusError( err );
 	}
 }
 
@@ -564,7 +564,7 @@ void MainWindow::onTcpPortActive(bool active)
 	}
 }
 
-void MainWindow::onConnectionError(const QString &msg)
+void MainWindow::setStatusError(const QString &msg)
 {
     m_statusText->setText( msg );
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,7 +25,6 @@
 #include <QSettings>
 #include <QDebug>
 #include <QTimer>
-#include <QMessageBox>
 #include <QScrollBar>
 
 #include <errno.h>
@@ -459,6 +458,8 @@ void MainWindow::sendModbusRequest( void )
 	}
 	else
 	{
+		QString err;
+
 		if( ret < 0 )
 		{
 			if(
@@ -468,24 +469,30 @@ void MainWindow::sendModbusRequest( void )
 					errno == EIO
 																	)
 			{
-				QMessageBox::critical( this, tr( "I/O error" ),
-					tr( "I/O error: did not receive any data from slave." ) );
+				err += tr( "I/O error" );
+				err += ": ";
+				err += tr( "did not receive any data from slave." );
 			}
 			else
 			{
-				QMessageBox::critical( this, tr( "Protocol error" ),
-					tr( "Slave threw exception \"%1\" or "
-						"function not implemented." ).
-								arg( modbus_strerror( errno ) ) );
+				err += tr( "Protocol error" );
+				err += ": ";
+				err += tr( "Slave threw exception '" );
+				err += modbus_strerror( errno );
+				err += tr( "' or function not implemented." );
 			}
 		}
 		else
 		{
-			QMessageBox::critical( this, tr( "Protocol error" ),
-				tr( "Number of registers returned does not "
+			err += tr( "Protocol error" );
+			err += ": ";
+			err += tr( "Number of registers returned does not "
 					"match number of registers "
-							"requested!" ) );
+							"requested!" );
 		}
+
+		if( err.size() > 0 )
+			onConnectionError( err );
 	}
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -86,6 +86,7 @@ private slots:
     void onRtuPortActive(bool active);
     void onAsciiPortActive(bool active);
     void onTcpPortActive(bool active);
+    void onConnectionError(const QString &msg);
 
 private:
     Ui::MainWindowClass * ui;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -79,14 +79,14 @@ private slots:
     void updateRegisterView( void );
     void enableHexView( void );
     void sendModbusRequest( void );
-    void resetStatus( void );
     void pollForDataOnBus( void );
     void openBatchProcessor();
     void aboutQModBus( void );
     void onRtuPortActive(bool active);
     void onAsciiPortActive(bool active);
     void onTcpPortActive(bool active);
-    void onConnectionError(const QString &msg);
+    void resetStatus( void );
+    void setStatusError(const QString &msg);
 
 private:
     Ui::MainWindowClass * ui;

--- a/src/rtusettingswidget.cpp
+++ b/src/rtusettingswidget.cpp
@@ -27,8 +27,8 @@ void RtuSettingsWidget::changeModbusInterface(const QString& port, char parity)
 
     if( modbus_connect( m_serialModbus ) == -1 )
     {
-        QMessageBox::critical( this, tr( "Connection failed" ),
-            tr( "Could not connect serial port!" ) );
+        emit connectionError( tr( "Could not connect serial port!" ) );
+
 	releaseSerialModbus();
     }
 }

--- a/src/rtusettingswidget.cpp
+++ b/src/rtusettingswidget.cpp
@@ -3,9 +3,6 @@
 #include "ui_serialsettingswidget.h"
 #include "modbus.h"
 
-#include <QMessageBox>
-
-
 RtuSettingsWidget::RtuSettingsWidget(QWidget *parent) :
     SerialSettingsWidget(parent)
 {

--- a/src/serialsettingswidget.cpp
+++ b/src/serialsettingswidget.cpp
@@ -1,5 +1,4 @@
 #include <QSettings>
-#include <QMessageBox>
 #include "qextserialenumerator.h"
 #include "serialsettingswidget.h"
 #include "ui_serialsettingswidget.h"
@@ -116,9 +115,7 @@ void SerialSettingsWidget::changeSerialPort( int )
 	}
 	else
 	{
-		QMessageBox::critical( this, tr( "No serial port found" ),
-				tr( "Could not find any serial port "
-						"on this computer!" ) );
+		emit connectionError( tr( "No serial port found" ) );
 	}
 }
 

--- a/src/serialsettingswidget.h
+++ b/src/serialsettingswidget.h
@@ -32,6 +32,7 @@ protected:
 
 signals:
 	void serialPortActive(bool active);
+	void connectionError(const QString &msg);
 
 public slots:
 	void changeSerialPort(int);

--- a/src/tcpipsettingswidget.cpp
+++ b/src/tcpipsettingswidget.cpp
@@ -33,8 +33,8 @@ void TcpIpSettingsWidget::changeModbusInterface(const QString &address, int port
     m_tcpModbus = modbus_new_tcp( address.toLatin1().constData(), portNbr );
     if( modbus_connect( m_tcpModbus ) == -1 )
     {
-        QMessageBox::critical( this, tr( "Connection failed" ),
-            tr( "Could not connect tcp/ip port!" ) );
+        emit connectionError( tr( "Could not connect tcp/ip port!" ) );
+
         ui->btnApply->setEnabled(true);
     	releaseTcpModbus();
     }

--- a/src/tcpipsettingswidget.cpp
+++ b/src/tcpipsettingswidget.cpp
@@ -2,7 +2,6 @@
 #include "ui_tcpipsettingswidget.h"
 #include "modbus-tcp.h"
 #include <QIntValidator>
-#include <QMessageBox>
 #include <QDebug>
 
 TcpIpSettingsWidget::TcpIpSettingsWidget(QWidget *parent) :

--- a/src/tcpipsettingswidget.h
+++ b/src/tcpipsettingswidget.h
@@ -32,6 +32,7 @@ private slots:
 
 signals:
     void tcpPortActive(bool val);
+    void connectionError(const QString &msg);
 
 private:
     Ui::TcpIpSettingsWidget *ui;


### PR DESCRIPTION
The pop-up error-message dialogs are annoying when trying to debug connections.
This PR outputs the message to the status area.
The status area returns to the default "Ready" message after some time.

Can you also confirm the indentation-type is tabs and not spaces?

Related:
https://github.com/ed-chemnitz/qmodbus/issues/13