### PR TITLE
Poll feature

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -107,6 +107,10 @@ MainWindow::MainWindow( QWidget * _parent ) :
 
 	m_poll_timer = new QTimer( this );
 	connect( m_poll_timer, SIGNAL(timeout()), this, SLOT(sendModbusRequest()));
+
+	m_status_timer = new QTimer( this );
+	connect( m_status_timer, SIGNAL(timeout()), this, SLOT(resetStatus()));
+	m_status_timer->setSingleShot(true);
 }
 
 
@@ -468,7 +472,7 @@ void MainWindow::sendModbusRequest( void )
 			m_statusText->setText(
 					tr( "Values successfully sent" ) );
 			m_statusInd->setStyleSheet( "background: #0b0;" );
-			QTimer::singleShot( 2000, this, SLOT( resetStatus() ) );
+			m_status_timer->start( 2000 );
 		}
 		else
 		{
@@ -618,5 +622,5 @@ void MainWindow::setStatusError(const QString &msg)
 
     m_statusInd->setStyleSheet( "background: red;" );
 
-    QTimer::singleShot( 2000, this, SLOT( resetStatus() ) );
+    m_status_timer->start( 2000 );
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -105,12 +105,12 @@ MainWindow::MainWindow( QWidget * _parent ) :
 	connect( t, SIGNAL(timeout()), this, SLOT(pollForDataOnBus()));
 	t->start( 5 );
 
-	m_poll_timer = new QTimer( this );
-	connect( m_poll_timer, SIGNAL(timeout()), this, SLOT(sendModbusRequest()));
+	m_pollTimer = new QTimer( this );
+	connect( m_pollTimer, SIGNAL(timeout()), this, SLOT(sendModbusRequest()));
 
-	m_status_timer = new QTimer( this );
-	connect( m_status_timer, SIGNAL(timeout()), this, SLOT(resetStatus()));
-	m_status_timer->setSingleShot(true);
+	m_statusTimer = new QTimer( this );
+	connect( m_statusTimer, SIGNAL(timeout()), this, SLOT(resetStatus()));
+	m_statusTimer->setSingleShot(true);
 }
 
 
@@ -127,7 +127,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
 		if( m_modbus != NULL )
 			m_poll = true;
 
-		if( ! m_poll_timer->isActive() )
+		if( ! m_pollTimer->isActive() )
 			ui->sendBtn->setText( tr("Poll") );
 	}
 }
@@ -138,7 +138,7 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
 	{
 		m_poll = false;
 
-		if( ! m_poll_timer->isActive() )
+		if( ! m_pollTimer->isActive() )
 			ui->sendBtn->setText( tr("Send") );
 	}
 }
@@ -146,9 +146,9 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
 void MainWindow::onSendButtonPress( void )
 {
 	//if already polling then stop
-	if( m_poll_timer->isActive() )
+	if( m_pollTimer->isActive() )
 	{
-		m_poll_timer->stop();
+		m_pollTimer->stop();
 		ui->sendBtn->setText( tr("Send") );
 	}
 	else
@@ -156,7 +156,7 @@ void MainWindow::onSendButtonPress( void )
 		//if polling requested then enable timer
 		if( m_poll )
 		{
-			m_poll_timer->start( 1000 );
+			m_pollTimer->start( 1000 );
 			ui->sendBtn->setText( tr("Stop") );
 		}
 
@@ -472,7 +472,7 @@ void MainWindow::sendModbusRequest( void )
 			m_statusText->setText(
 					tr( "Values successfully sent" ) );
 			m_statusInd->setStyleSheet( "background: #0b0;" );
-			m_status_timer->start( 2000 );
+			m_statusTimer->start( 2000 );
 		}
 		else
 		{
@@ -622,5 +622,5 @@ void MainWindow::setStatusError(const QString &msg)
 
     m_statusInd->setStyleSheet( "background: red;" );
 
-    m_status_timer->start( 2000 );
+    m_statusTimer->start( 2000 );
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,7 +47,8 @@ extern MainWindow * globalMainWin;
 MainWindow::MainWindow( QWidget * _parent ) :
 	QMainWindow( _parent ),
 	ui( new Ui::MainWindowClass ),
-	m_modbus( NULL )
+	m_modbus( NULL ),
+	m_poll(false)
 {
 	ui->setupUi(this);
 
@@ -110,6 +111,28 @@ MainWindow::MainWindow( QWidget * _parent ) :
 MainWindow::~MainWindow()
 {
 	delete ui;
+}
+
+void MainWindow::keyPressEvent(QKeyEvent* event)
+{
+	if( event->key() == Qt::Key_Control )
+	{
+		//set flag to request polling
+		if( m_modbus != NULL )
+			m_poll = true;
+
+		ui->sendBtn->setText( tr("Poll") );
+	}
+}
+
+void MainWindow::keyReleaseEvent(QKeyEvent* event)
+{
+	if( event->key() == Qt::Key_Control )
+	{
+		m_poll = false;
+
+		ui->sendBtn->setText( tr("Send") );
+	}
 }
 
 void MainWindow::busMonitorAddItem( bool isRequest,

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,6 +26,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QTimer>
 
 #include "modbus.h"
 #include "ui_about.h"
@@ -79,6 +80,7 @@ private slots:
     void updateRegisterView( void );
     void enableHexView( void );
     void sendModbusRequest( void );
+    void onSendButtonPress( void );
     void pollForDataOnBus( void );
     void openBatchProcessor();
     void aboutQModBus( void );
@@ -96,6 +98,7 @@ private:
     modbus_t * m_modbus;
     QWidget * m_statusInd;
     QLabel * m_statusText;
+    QTimer * m_poll_timer;
     bool m_poll;
 };
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -98,8 +98,8 @@ private:
     modbus_t * m_modbus;
     QWidget * m_statusInd;
     QLabel * m_statusText;
-    QTimer * m_poll_timer;
-    QTimer * m_status_timer;
+    QTimer * m_pollTimer;
+    QTimer * m_statusTimer;
     bool m_poll;
 };
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -89,11 +89,14 @@ private slots:
     void setStatusError(const QString &msg);
 
 private:
+    void keyPressEvent(QKeyEvent* event);
+    void keyReleaseEvent(QKeyEvent* event);
+
     Ui::MainWindowClass * ui;
     modbus_t * m_modbus;
     QWidget * m_statusInd;
     QLabel * m_statusText;
-
+    bool m_poll;
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -99,6 +99,7 @@ private:
     QWidget * m_statusInd;
     QLabel * m_statusText;
     QTimer * m_poll_timer;
+    QTimer * m_status_timer;
     bool m_poll;
 };
 


### PR DESCRIPTION
The PR adds a polling feature which is useful for testing and debugging modbus systems

Holding the Ctrl key changes the send-button text from "Send" to "Poll".

If you click "Poll" then the current modbus request will be sent, once per second, indefinitely.
The send-button text will change to "Stop", allowing you to stop the polling