### PR TITLE
Fix crash when switching serial ports

### DIFF
--- a/src/rtusettingswidget.cpp
+++ b/src/rtusettingswidget.cpp
@@ -26,6 +26,6 @@ void RtuSettingsWidget::changeModbusInterface(const QString& port, char parity)
     {
         emit connectionError( tr( "Could not connect serial port!" ) );
 
-	releaseSerialModbus();
+        releaseSerialModbus();
     }
 }

--- a/src/serialsettingswidget.cpp
+++ b/src/serialsettingswidget.cpp
@@ -5,8 +5,8 @@
 
 SerialSettingsWidget::SerialSettingsWidget(QWidget *parent) :
 	QWidget(parent),
-	ui(new Ui::SerialSettingsWidget)
-  , m_serialModbus( NULL )
+	ui(new Ui::SerialSettingsWidget),
+	m_serialModbus( NULL )
 {
 	ui->setupUi(this);
 	enableGuiItems(false);
@@ -112,6 +112,8 @@ void SerialSettingsWidget::changeSerialPort( int )
 		}
 
 		changeModbusInterface(port, parity);
+
+		emit serialPortActive(true);
 	}
 	else
 	{


### PR DESCRIPTION
Switching port after sending a message was crashing the program

How:
Open QModbus and select the RTU tab.
Make it active, select a valid port and hit send (If the first port was not valid you will need to toggle active checkbox).
The message should be sent and a response or timeout received.
Switch to another port (the program should crash).

Why:
Toggling active checkbox causes mainwindow to fetch modbus_t pointer from rtu widget.
If a valid port was selected then modbus_t should be valid.
Changing serial port settings frees modbus_t and allocates a new one.
mainwindow is not informed so modbus_poll() uses the freed one and causes a crash.

Fix:
When changing the serial port we now emit serialPortActive(true).
This causes mainwindow to update modbus_t thereby avoiding the crash.

This solution also means we do not need to toggle the active checkbox when we change the serial port.

Maybe related to https://github.com/ed-chemnitz/qmodbus/issues/10