### PR TITLE
Handle TCP disconnections

### DIFF
--- a/forms/tcpipsettingswidget.ui
+++ b/forms/tcpipsettingswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>547</width>
-    <height>156</height>
+    <height>217</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -90,33 +90,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="rightMargin">
-      <number>6</number>
-     </property>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnApply">
-       <property name="text">
-        <string>Apply</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,6 +47,7 @@ MainWindow::MainWindow( QWidget * _parent ) :
 	QMainWindow( _parent ),
 	ui( new Ui::MainWindowClass ),
 	m_modbus( NULL ),
+	m_tcpActive(false),
 	m_poll(false)
 {
 	ui->setupUi(this);
@@ -381,8 +382,12 @@ void MainWindow::enableHexView( void )
 
 void MainWindow::sendModbusRequest( void )
 {
+	if( m_tcpActive )
+		ui->tcpSettingsWidget->tcpConnect();
+
 	if( m_modbus == NULL )
 	{
+		setStatusError( tr("Not configured!") );
 		return;
 	}
 
@@ -539,8 +544,7 @@ void MainWindow::sendModbusRequest( void )
 			err += tr( "Protocol error" );
 			err += ": ";
 			err += tr( "Number of registers returned does not "
-					"match number of registers "
-							"requested!" );
+					"match number of registers requested!" );
 		}
 
 		if( err.size() > 0 )
@@ -582,6 +586,7 @@ void MainWindow::onRtuPortActive(bool active)
 			modbus_register_monitor_add_item_fnc(m_modbus, MainWindow::stBusMonitorAddItem);
 			modbus_register_monitor_raw_data_fnc(m_modbus, MainWindow::stBusMonitorRawData);
 		}
+		m_tcpActive = false;
 	}
 	else {
 		m_modbus = NULL;
@@ -596,6 +601,7 @@ void MainWindow::onAsciiPortActive(bool active)
             modbus_register_monitor_add_item_fnc(m_modbus, MainWindow::stBusMonitorAddItem);
             modbus_register_monitor_raw_data_fnc(m_modbus, MainWindow::stBusMonitorRawData);
         }
+        m_tcpActive = false;
     }
     else {
         m_modbus = NULL;
@@ -604,6 +610,8 @@ void MainWindow::onAsciiPortActive(bool active)
 
 void MainWindow::onTcpPortActive(bool active)
 {
+	m_tcpActive = active;
+
 	if (active) {
 		m_modbus = ui->tcpSettingsWidget->modbus();
 		if (m_modbus) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -100,6 +100,7 @@ private:
     QLabel * m_statusText;
     QTimer * m_pollTimer;
     QTimer * m_statusTimer;
+    bool m_tcpActive;
     bool m_poll;
 };
 

--- a/src/tcpipsettingswidget.cpp
+++ b/src/tcpipsettingswidget.cpp
@@ -6,8 +6,8 @@
 
 TcpIpSettingsWidget::TcpIpSettingsWidget(QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::TcpIpSettingsWidget)
-,   m_tcpModbus(0)
+    ui(new Ui::TcpIpSettingsWidget),
+    m_tcpModbus(0)
 {
     ui->setupUi(this);
     connect(ui->edNetworkAddress, SIGNAL(textChanged(QString)), this, SLOT(onEdNetworkAddressTextChanged(QString)));
@@ -59,9 +59,15 @@ void TcpIpSettingsWidget::enableGuiItems(bool checked)
 void TcpIpSettingsWidget::on_cbEnabled_clicked(bool checked)
 {
     enableGuiItems(checked);
+    emit tcpPortActive(checked);
 }
 
 void TcpIpSettingsWidget::on_btnApply_clicked()
+{
+    tcpConnect();
+}
+
+void TcpIpSettingsWidget::tcpConnect()
 {
     int portNbr = ui->edPort->text().toInt();
     ui->btnApply->setEnabled(false);

--- a/src/tcpipsettingswidget.cpp
+++ b/src/tcpipsettingswidget.cpp
@@ -10,7 +10,6 @@ TcpIpSettingsWidget::TcpIpSettingsWidget(QWidget *parent) :
     m_tcpModbus(0)
 {
     ui->setupUi(this);
-    connect(ui->edNetworkAddress, SIGNAL(textChanged(QString)), this, SLOT(onEdNetworkAddressTextChanged(QString)));
     ui->edPort->setValidator(new QIntValidator(this));
     enableGuiItems(false);
 }
@@ -32,9 +31,8 @@ void TcpIpSettingsWidget::changeModbusInterface(const QString &address, int port
     m_tcpModbus = modbus_new_tcp( address.toLatin1().constData(), portNbr );
     if( modbus_connect( m_tcpModbus ) == -1 )
     {
-        emit connectionError( tr( "Could not connect tcp/ip port!" ) );
+        emit connectionError( tr( "Could not connect to TCP/IP port!" ) );
 
-        ui->btnApply->setEnabled(true);
     	releaseTcpModbus();
     }
 }
@@ -55,32 +53,15 @@ void TcpIpSettingsWidget::enableGuiItems(bool checked)
     ui->edNetworkAddress->setEnabled(checked);
 }
 
-
 void TcpIpSettingsWidget::on_cbEnabled_clicked(bool checked)
 {
     enableGuiItems(checked);
     emit tcpPortActive(checked);
 }
 
-void TcpIpSettingsWidget::on_btnApply_clicked()
-{
-    tcpConnect();
-}
-
 void TcpIpSettingsWidget::tcpConnect()
 {
     int portNbr = ui->edPort->text().toInt();
-    ui->btnApply->setEnabled(false);
     changeModbusInterface(ui->edNetworkAddress->text(), portNbr);
     emit tcpPortActive(ui->cbEnabled->isChecked());
-}
-
-void TcpIpSettingsWidget::onEdNetworkAddressTextChanged(const QString &)
-{
-    ui->btnApply->setEnabled(true);
-}
-
-void TcpIpSettingsWidget::on_edPort_textChanged(const QString &)
-{
-    ui->btnApply->setEnabled(true);
 }

--- a/src/tcpipsettingswidget.h
+++ b/src/tcpipsettingswidget.h
@@ -27,9 +27,6 @@ protected:
 
 private slots:
     void on_cbEnabled_clicked(bool checked);
-    void on_btnApply_clicked();
-    void onEdNetworkAddressTextChanged(const QString &arg1);
-    void on_edPort_textChanged(const QString &arg1);
 
 signals:
     void tcpPortActive(bool val);

--- a/src/tcpipsettingswidget.h
+++ b/src/tcpipsettingswidget.h
@@ -18,6 +18,7 @@ public:
     // IModbus interface
     virtual modbus_t *modbus() { return m_tcpModbus; }
     virtual int setupModbusPort();
+    void tcpConnect();
 
 protected:
     void changeModbusInterface(const QString& address, int portNbr);


### PR DESCRIPTION
This PR opens a new TCP/IP connection for each ModbusTCP request.

Up to now when a TCP connection breaks, the user must modify
either the ip address or port to re-enable the Apply button
which can then be used to open a new connection.

Now when debugging ModbusTCP connections we can configure the correct address and start polling.
We are then free to modify wiring, slave device settings or laptop ip settings etc. without needing to
reconfigure QModBus using the procedure above.

These changes mean the Apply button is obsolete so it has been removed.