### PR TITLE
Add default unix installation prefix to fix QMake warning

### DIFF
--- a/deployment.pri
+++ b/deployment.pri
@@ -15,6 +15,12 @@ win32 {
 	INSTALLS += dlls qt5platforms
 }
 
+unix {
+	isEmpty(PREFIX) {
+		PREFIX = /usr/local/bin
+	}
+}
+
 target.path = $$PREFIX
 
 INSTALLS += target


### PR DESCRIPTION
This fixes the following qmake warning:
WARNING: target.path is not defined: install target not created

Relevant issue: https://github.com/ed-chemnitz/qmodbus/issues/26