### PR TITLE
added extra baud rates as suppoted by libmodbus

### DIFF
--- a/forms/serialsettingswidget.ui
+++ b/forms/serialsettingswidget.ui
@@ -105,6 +105,36 @@
        <string>115200</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>230400</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>250000</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>460800</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>500000</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>921600</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>1000000</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="2" column="2">


### PR DESCRIPTION
Libmodbus supports more baud rates than qmodbus displays in the menu, I have added extra menu items to support these.

Note: support is hardware-specific. I have tested up to 460800 baud, but do not have hardware that can handle higher baud rates.