### PR TITLE
Improve regTable usability

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -23,6 +23,12 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QTabWidget" name="tabWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="currentIndex">
          <number>1</number>
         </property>

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -257,7 +257,10 @@
          <item>
           <widget class="QTableWidget" name="regTable">
            <attribute name="horizontalHeaderDefaultSectionSize">
-            <number>60</number>
+            <number>100</number>
+           </attribute>
+           <attribute name="horizontalHeaderStretchLastSection">
+            <bool>true</bool>
            </attribute>
            <attribute name="verticalHeaderVisible">
             <bool>false</bool>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -93,8 +93,6 @@ MainWindow::MainWindow( QWidget * _parent ) :
 	updateRequestPreview();
 	enableHexView();
 
-	ui->regTable->setColumnWidth( 0, 150 );
-
 	m_statusInd = new QWidget;
 	m_statusInd->setFixedSize( 16, 16 );
 	m_statusText = new QLabel;
@@ -380,7 +378,8 @@ void MainWindow::updateRegisterView( void )
 		ui->regTable->setItem( i, DataColumn, dataItem );
 	}
 
-	ui->regTable->setColumnWidth( 0, 150 );
+	if( rowCount > 0 )
+		ui->regTable->resizeColumnToContents(0);
 }
 
 
@@ -528,6 +527,8 @@ void MainWindow::sendModbusRequest( void )
 				ui->regTable->setItem( i, DataColumn,
 								dataItem );
 			}
+
+			ui->regTable->resizeColumnToContents(0);
 		}
 	}
 	else


### PR DESCRIPTION
This tool is exactly what I needed and really helped me debug some of my modbus issues, thanks for making it!

Fixes a couple of minor UI issues:

1. If you stretch the window vertically the settings tabs expand unnecessarily giving you less space to view multiple coil/registers.
2. The default/enforced width of 150 is not big enough to display the contents of column 0 on my system (Ubuntu 21.04).

Before:
![Screenshot from 2021-08-21 12-54-20](https://user-images.githubusercontent.com/9699636/130321312-d31e26cb-3de8-4135-ab81-52602b2bcef4.png)

After:
![Screenshot from 2021-08-21 13-00-20](https://user-images.githubusercontent.com/9699636/130321316-e209be1c-14a9-4c41-99a1-f193bb683f4a.png)
