### PR TITLE
correcting debian packaging for qt5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qmodbus
 Section: electronics
 Priority: optional
 Maintainer: Jean-Samuel Reynaud <js.reynaud@gmail.com>
-Build-Depends: debhelper (>= 4.0.0), cmake, libqt4-dev
+Build-Depends: debhelper (>= 4.0.0), qtbase5-dev-tools
 Standards-Version: 3.6.1.1
 
 Package: qmodbus

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
 
-
+export QT_SELECT=qt5
 %:
 	dh $@


### PR DESCRIPTION
Hello
I corrected the debian packaging files for qt5.
There is also a version mismatch in debian/changelog. It is indicated 1.0-0 whereas qmodbus version is 0.3.0.
I didn't changed it in the case you were willing to change qmodbus version.
Bests.